### PR TITLE
fix bug

### DIFF
--- a/office_word_count/text.py
+++ b/office_word_count/text.py
@@ -39,7 +39,7 @@ class Text:
         return Text(SPACES.sub("", self.value))
 
     def no_asian(self):
-        return Text(ASIANS.sub("", self.value))
+        return Text(ASIANS.sub(" ", self.value))
 
     def only_asian(self):
         return Text("".join(ASIANS.findall(self.value)))


### PR DESCRIPTION
It would count the text "a啊e" as 2 words while MS-Word count 3 words before. I fix this bug